### PR TITLE
Fixed goroutines on recursive algorithms

### DIFF
--- a/recursive_optimized.go
+++ b/recursive_optimized.go
@@ -16,24 +16,38 @@ func FibonacciRecursiveOptimized(n int, ctx context.Context) *big.Int {
 	result := big.NewInt(0)
 	done := make(chan struct{})
 
+	var recursive func(int, context.Context) *big.Int
+	recursive = func(n int, ctx context.Context) *big.Int {
+		if n <= 1 {
+			return big.NewInt(int64(n))
+		}
+		select {
+		case <-ctx.Done():
+			return big.NewInt(0)
+		default:
+			mu.Lock()
+			if val, exist := lookupTable[n]; exist {
+				result.Set(val)
+				mu.Unlock()
+				return result
+			}
+
+			mu.Unlock()
+
+			a := recursive(n-1, ctx)
+			b := recursive(n-2, ctx)
+
+			mu.Lock()
+			lookupTable[n] = new(big.Int).Add(a, b)
+			result.Set(lookupTable[n])
+			mu.Unlock()
+			return result
+		}
+	}
+
 	go func() {
 		defer close(done)
-		mu.Lock()
-		if val, exist := lookupTable[n]; exist {
-			result.Set(val)
-			mu.Unlock()
-			return
-		}
-		
-		mu.Unlock()
-
-		a := FibonacciRecursiveOptimized(n-1, ctx)
-		b := FibonacciRecursiveOptimized(n-2, ctx)
-
-		mu.Lock()
-		lookupTable[n] = new(big.Int).Add(a, b)
-		result.Set(lookupTable[n])
-		mu.Unlock()
+		result.Set(recursive(n, ctx))
 	}()
 
 	select {


### PR DESCRIPTION
Before, a new goroutine started for each recursive call, so we encountered a few lost

Here some benchmark with 1 second limit:

|      Algorithm      | Without goroutines | With goroutines (unfixed) |        With goroutines (fixed)         |
| :-----------------: | :----------------: | :-----------------------: | :------------------------------------: |
|      Recursive      |       32nth        |           23nth           |                 33nth                  |
| Recursive optimized |     ~ 500K nth     |        ~ 118K nth         | ~450K nth (loss due to sync mutex imo) |
